### PR TITLE
Enhancements for Large-Scale Duplicate Cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,14 @@ IMMICH_DRY_RUN=true
 
 # Permanently delete instead of moving to recycle bin (true/false)
 IMMICH_DEFINITELY=false
+
+# Only process duplicate pairs (exactly 2 files); skip groups with 3+ files for manual selection
+IMMICH_ONLY_PAIRS=false
+
+# May the kept image retain its own metadata (albums, tags, location)?
+# true = yes, false = remove before transfer
+IMMICH_KEEP_METADATA=true
+
+# Transfer metadata from to-be-deleted assets onto the kept asset?
+# true = transfer (augment only, never overwrite), false = do not transfer
+IMMICH_TRANSFER_METADATA=true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Immich Duplicates Script - Environment Configuration
+# Copy this file to .env and adjust the values.
+# The script loads .env automatically if python-dotenv is installed (pip install python-dotenv).
+
+# Immich server URL (e.g. https://immich.example.com or http://192.168.1.100:2283)
+IMMICH_SERVER=https://immich.example.com
+
+# API key from Immich (Settings → API Keys)
+IMMICH_API_KEY=ENTER_YOUR_API_KEY_HERE
+
+# Create a log file with timestamp (true/false)
+IMMICH_ENABLE_LOG=true
+
+# Simulation mode - only show what would be deleted, do not actually delete (true/false)
+IMMICH_DRY_RUN=true
+
+# Permanently delete instead of moving to recycle bin (true/false)
+IMMICH_DEFINITELY=false

--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,13 @@ IMMICH_KEEP_METADATA=true
 # Transfer metadata from to-be-deleted assets onto the kept asset?
 # true = transfer (augment only, never overwrite), false = do not transfer
 IMMICH_TRANSFER_METADATA=true
+
+# Interactive confirmation mode - ask before processing each duplicate group (true/false)
+# When true: prompts [Y/n] per group; with DRY_RUN=true only logs, with DRY_RUN=false processes immediately
+IMMICH_CONFIRM=false
+
+# Request timeout in seconds for API calls (default: 5). Increase for slow servers.
+# IMMICH_REQUEST_TIMEOUT=5
+
+# Batch size for bulk deletion in non-CONFIRM mode (default: 500). Limits payload size per request.
+# IMMICH_DELETE_BATCH_SIZE=500

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Environment (contains API key)
+.env
+
+# Log files
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+env/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Python script to intelligently detect and delete **duplicate photos/videos** on 
   2. **Preferred format** : `.heic` in priority
   3. **File's size** (we keep the largest)
   4. **Richness of EXIF metadata**
+- 📋 **Only pairs mode** – process only groups with exactly 2 files (e.g. JPG+HEIC); skip series with 3+ for manual selection
+- 🔄 **Metadata transfer** – optionally transfer albums, tags, and location/EXIF from deleted assets to the kept one (augment only, never overwrite)
 - 🧪 **Simulation mode** to test without deleting, useful for viewing logs
 - 🗑️ Option to delete to the recycle bin or permanently
 - 📄 Automatic logging to a `.log` file (optional)
@@ -23,6 +25,22 @@ Python script to intelligently detect and delete **duplicate photos/videos** on 
 - Immich server operational (self-hosted or public)
 - A valid **API key**
 - Python ≥ 3.7
+
+### API Key and Permissions
+
+Create an API key in Immich under **Settings → API Keys**. The key needs the following permissions:
+
+| Permission | Purpose |
+|------------|---------|
+| `duplicate.read` | Retrieve duplicate groups |
+| `asset.delete` | Delete duplicate assets |
+| `asset.update` | Transfer location/EXIF metadata (when `IMMICH_TRANSFER_METADATA=true`) |
+| `album.read` | Read album memberships for metadata transfer |
+| `album.asset.create` | Add kept asset to albums (when `IMMICH_TRANSFER_METADATA=true`) |
+| `album.asset.delete` | Remove kept asset from albums (when `IMMICH_KEEP_METADATA=false`) |
+| `tag.asset` | Add/remove tags for metadata transfer |
+
+A full-access API key includes all of these. If you only use `IMMICH_TRANSFER_METADATA=false` and `IMMICH_KEEP_METADATA=true`, the minimum required permissions are `duplicate.read` and `asset.delete`.
 
 ---
 
@@ -61,6 +79,9 @@ Python script to intelligently detect and delete **duplicate photos/videos** on 
    - `IMMICH_DRY_RUN` – `true` to simulate only (default), `false` to actually delete
    - `IMMICH_DEFINITELY` – `false` for recycle bin (default), `true` for permanent deletion
    - `IMMICH_ENABLE_LOG` – `true` or `false` for log file creation
+   - `IMMICH_ONLY_PAIRS` – `false` (default) to process all groups, `true` to process only groups with exactly 2 files
+   - `IMMICH_KEEP_METADATA` – `true` (default) to let the kept image keep its metadata, `false` to remove it before transfer
+   - `IMMICH_TRANSFER_METADATA` – `true` (default) to transfer albums, tags, location from deleted assets to the kept one
 
 Alternatively, set these as environment variables directly instead of using a `.env` file.
 
@@ -96,6 +117,8 @@ Script Python pour détecter et supprimer intelligemment les **doublons photos/v
   - **Format préféré** : `.heic` en priorité
   - **Taille du fichier** (on garde le plus lourd)
   - **Richesse des métadonnées EXIF**
+- 📋 **Mode paires uniquement** – ne traiter que les groupes de 2 fichiers (ex. JPG+HEIC) ; ignorer les séries de 3+ pour sélection manuelle
+- 🔄 **Transfert de métadonnées** – transférer albums, tags et localisation/EXIF des fichiers supprimés vers le gardé (augmentation uniquement)
 - 🧪 **Mode simulation** pour tester sans supprimer, utile pour voir les logs
 - 🗑️ Option de suppression dans la corbeille ou définitive
 - 📄 Journalisation automatique dans un fichier `.log` (optionnelle)
@@ -107,6 +130,22 @@ Script Python pour détecter et supprimer intelligemment les **doublons photos/v
 - Serveur Immich opérationnel (auto-hébergé ou public)
 - Une **clé API** valide
 - Python ≥ 3.7
+
+### Clé API et droits requis
+
+Créez une clé API dans Immich via **Paramètres → Clés API**. La clé doit posséder les droits suivants :
+
+| Droit | Rôle |
+|-------|------|
+| `duplicate.read` | Récupérer les groupes de doublons |
+| `asset.delete` | Supprimer les assets en doublon |
+| `asset.update` | Transférer localisation/EXIF (si `IMMICH_TRANSFER_METADATA=true`) |
+| `album.read` | Lire les appartenances aux albums pour le transfert |
+| `album.asset.create` | Ajouter le gardé aux albums (si `IMMICH_TRANSFER_METADATA=true`) |
+| `album.asset.delete` | Retirer le gardé des albums (si `IMMICH_KEEP_METADATA=false`) |
+| `tag.asset` | Ajouter/retirer des tags pour le transfert |
+
+Une clé API avec accès complet inclut tous ces droits. Si vous utilisez uniquement `IMMICH_TRANSFER_METADATA=false` et `IMMICH_KEEP_METADATA=true`, les droits minimaux requis sont `duplicate.read` et `asset.delete`.
 
 ---
 
@@ -145,6 +184,9 @@ Script Python pour détecter et supprimer intelligemment les **doublons photos/v
    - `IMMICH_DRY_RUN` – `true` pour simuler uniquement (par défaut), `false` pour supprimer réellement
    - `IMMICH_DEFINITELY` – `false` pour la corbeille (par défaut), `true` pour suppression définitive
    - `IMMICH_ENABLE_LOG` – `true` ou `false` pour la création du fichier log
+   - `IMMICH_ONLY_PAIRS` – `false` (défaut) pour traiter tous les groupes, `true` pour n'accepter que les paires de 2 fichiers
+   - `IMMICH_KEEP_METADATA` – `true` (défaut) pour que le gardé conserve ses métadonnées, `false` pour les retirer avant transfert
+   - `IMMICH_TRANSFER_METADATA` – `true` (défaut) pour transférer albums, tags et localisation des supprimés vers le gardé
 
 Vous pouvez aussi définir ces variables d'environnement directement, sans fichier `.env`.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,62 @@ Python script to intelligently detect and delete **duplicate photos/videos** on 
 - Immich server operational (self-hosted or public)
 - A valid **API key**
 - Python ≥ 3.7
-- Requests module, simply install it with `pip install requests` in the terminal
+
+---
+
+## 📦 Installation
+
+1. Clone the repository and enter the directory
+2. Create a virtual environment:
+   ```bash
+   python -m venv .venv
+   ```
+3. Activate it (PowerShell on Windows):
+   ```powershell
+   .\.venv\Scripts\Activate.ps1
+   ```
+   On Linux/macOS:
+   ```bash
+   source .venv/bin/activate
+   ```
+4. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+---
+
+## ⚙️ Configuration
+
+1. Copy the example env file and edit it:
+   ```bash
+   copy .env.example .env   # Windows
+   cp .env.example .env    # Linux/macOS
+   ```
+2. Edit `.env` and set at least:
+   - `IMMICH_SERVER` – your Immich server URL (e.g. `https://immich.example.com`)
+   - `IMMICH_API_KEY` – your API key from Immich (Settings → API Keys)
+   - `IMMICH_DRY_RUN` – `true` to simulate only (default), `false` to actually delete
+   - `IMMICH_DEFINITELY` – `false` for recycle bin (default), `true` for permanent deletion
+   - `IMMICH_ENABLE_LOG` – `true` or `false` for log file creation
+
+Alternatively, set these as environment variables directly instead of using a `.env` file.
+
+---
+
+## 🚀 Usage
+
+```bash
+python immich_duplicates_en.py
+```
+
+For the French version:
+
+```bash
+python immich_duplicates_fr.py
+```
+
+**Tip:** Run with `IMMICH_DRY_RUN=true` (default) first to see what would be deleted without making any changes.
 
 ---
 
@@ -52,4 +107,59 @@ Script Python pour détecter et supprimer intelligemment les **doublons photos/v
 - Serveur Immich opérationnel (auto-hébergé ou public)
 - Une **clé API** valide
 - Python ≥ 3.7
-- Module requests, installez-le simplement en exécutant la commande `pip install requests` dans le terminal
+
+---
+
+## 📦 Installation
+
+1. Clonez le dépôt et entrez dans le répertoire
+2. Créez un environnement virtuel :
+   ```bash
+   python -m venv .venv
+   ```
+3. Activez-le (PowerShell sur Windows) :
+   ```powershell
+   .\.venv\Scripts\Activate.ps1
+   ```
+   Sur Linux/macOS :
+   ```bash
+   source .venv/bin/activate
+   ```
+4. Installez les dépendances :
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+---
+
+## ⚙️ Configuration
+
+1. Copiez le fichier d'exemple et modifiez-le :
+   ```bash
+   copy .env.example .env   # Windows
+   cp .env.example .env     # Linux/macOS
+   ```
+2. Éditez `.env` et configurez au minimum :
+   - `IMMICH_SERVER` – l'URL de votre serveur Immich (ex. `https://immich.example.com`)
+   - `IMMICH_API_KEY` – votre clé API (Paramètres → Clés API)
+   - `IMMICH_DRY_RUN` – `true` pour simuler uniquement (par défaut), `false` pour supprimer réellement
+   - `IMMICH_DEFINITELY` – `false` pour la corbeille (par défaut), `true` pour suppression définitive
+   - `IMMICH_ENABLE_LOG` – `true` ou `false` pour la création du fichier log
+
+Vous pouvez aussi définir ces variables d'environnement directement, sans fichier `.env`.
+
+---
+
+## 🚀 Utilisation
+
+```bash
+python immich_duplicates_fr.py
+```
+
+Pour la version anglaise :
+
+```bash
+python immich_duplicates_en.py
+```
+
+**Conseil :** Exécutez d'abord avec `IMMICH_DRY_RUN=true` (par défaut) pour voir ce qui serait supprimé sans modifier quoi que ce soit.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Python script to intelligently detect and delete **duplicate photos/videos** on 
 - 📋 **Only pairs mode** – process only groups with exactly 2 files (e.g. JPG+HEIC); skip series with 3+ for manual selection
 - 🔄 **Metadata transfer** – optionally transfer albums, tags, and location/EXIF from deleted assets to the kept one (augment only, never overwrite)
 - 🧪 **Simulation mode** to test without deleting, useful for viewing logs
+- ✔️ **Confirm mode** – interactive per-group approval [Y/n]; with DRY_RUN=true only logs, with DRY_RUN=false processes immediately
 - 🗑️ Option to delete to the recycle bin or permanently
 - 📄 Automatic logging to a `.log` file (optional)
 
@@ -82,6 +83,9 @@ A full-access API key includes all of these. If you only use `IMMICH_TRANSFER_ME
    - `IMMICH_ONLY_PAIRS` – `false` (default) to process all groups, `true` to process only groups with exactly 2 files
    - `IMMICH_KEEP_METADATA` – `true` (default) to let the kept image keep its metadata, `false` to remove it before transfer
    - `IMMICH_TRANSFER_METADATA` – `true` (default) to transfer albums, tags, location from deleted assets to the kept one
+   - `IMMICH_CONFIRM` – `true` to ask [Y/n] before each duplicate group; `false` (default) to add all to bulk list
+   - `IMMICH_REQUEST_TIMEOUT` – request timeout in seconds (default: 5); increase for slow servers
+   - `IMMICH_DELETE_BATCH_SIZE` – batch size for bulk deletion (default: 500); limits payload per request
 
 Alternatively, set these as environment variables directly instead of using a `.env` file.
 
@@ -99,7 +103,7 @@ For the French version:
 python immich_duplicates_fr.py
 ```
 
-**Tip:** Run with `IMMICH_DRY_RUN=true` (default) first to see what would be deleted without making any changes.
+**Tip:** Run with `IMMICH_DRY_RUN=true` (default) first to see what would be deleted. Use `IMMICH_CONFIRM=true` to approve each group [Y/n]; with `DRY_RUN=true` only logs, with `DRY_RUN=false` processes immediately.
 
 ---
 
@@ -120,6 +124,7 @@ Script Python pour détecter et supprimer intelligemment les **doublons photos/v
 - 📋 **Mode paires uniquement** – ne traiter que les groupes de 2 fichiers (ex. JPG+HEIC) ; ignorer les séries de 3+ pour sélection manuelle
 - 🔄 **Transfert de métadonnées** – transférer albums, tags et localisation/EXIF des fichiers supprimés vers le gardé (augmentation uniquement)
 - 🧪 **Mode simulation** pour tester sans supprimer, utile pour voir les logs
+- ✔️ **Mode confirmation** – validation interactive par groupe [O/n] ; avec DRY_RUN=true seulement log, avec DRY_RUN=false traitement immédiat
 - 🗑️ Option de suppression dans la corbeille ou définitive
 - 📄 Journalisation automatique dans un fichier `.log` (optionnelle)
 
@@ -187,6 +192,9 @@ Une clé API avec accès complet inclut tous ces droits. Si vous utilisez unique
    - `IMMICH_ONLY_PAIRS` – `false` (défaut) pour traiter tous les groupes, `true` pour n'accepter que les paires de 2 fichiers
    - `IMMICH_KEEP_METADATA` – `true` (défaut) pour que le gardé conserve ses métadonnées, `false` pour les retirer avant transfert
    - `IMMICH_TRANSFER_METADATA` – `true` (défaut) pour transférer albums, tags et localisation des supprimés vers le gardé
+   - `IMMICH_CONFIRM` – `true` pour demander [O/n] avant chaque groupe ; `false` (défaut) pour tout ajouter à la liste en bloc
+   - `IMMICH_REQUEST_TIMEOUT` – délai en secondes pour les requêtes API (défaut : 5) ; augmenter pour serveurs lents
+   - `IMMICH_DELETE_BATCH_SIZE` – taille des lots pour la suppression en bloc (défaut : 500) ; limite la taille du payload par requête
 
 Vous pouvez aussi définir ces variables d'environnement directement, sans fichier `.env`.
 
@@ -204,4 +212,4 @@ Pour la version anglaise :
 python immich_duplicates_en.py
 ```
 
-**Conseil :** Exécutez d'abord avec `IMMICH_DRY_RUN=true` (par défaut) pour voir ce qui serait supprimé sans modifier quoi que ce soit.
+**Conseil :** Exécutez d'abord avec `IMMICH_DRY_RUN=true` (par défaut) pour voir ce qui serait supprimé. Utilisez `IMMICH_CONFIRM=true` pour valider chaque groupe [O/n] ; avec `DRY_RUN=true` seulement log, avec `DRY_RUN=false` traitement immédiat.

--- a/immich_duplicates_en.py
+++ b/immich_duplicates_en.py
@@ -17,22 +17,41 @@ HEIC files (Apple originals), otherwise according to size, and finally EXIF meta
 - Detailed logging to a .log file if enabled
 - Ability to view files with their URLs in the logs
 
+Configuration can be provided via environment variables:
+  IMMICH_SERVER, IMMICH_API_KEY, IMMICH_ENABLE_LOG, IMMICH_DRY_RUN, IMMICH_DEFINITELY
+
 Improvements welcome! Feel free to share with attribution.
 """
 
 
+import os
 import requests
 import json
 from datetime import datetime
 import sys
 
-# User configuration:
-ENABLE_LOG_FILE = True # True = creates an immich_duplicates.log file, False = no log file
-SERVER = "https://immich.example.com"  # Replace with the URL of your Immich server or, failing that, the IP address.
-API_KEY = "ENTER_YOUR_API_KEY_HERE" # Replace with your Immich API key
-DRY_RUN = True  # True = only simulates to see the selected files in the output, does not actually delete them
-# Set to False to actually delete duplicates
-DEFINITELY = False  # True = permanently deleted, False = in the recycle bin
+# Load .env file if python-dotenv is installed (optional)
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+def get_env_bool(name: str, default: bool) -> bool:
+    """Parse boolean from environment variable."""
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.lower() in ('true', '1', 'yes', 'on')
+
+
+# User configuration (from env vars, with fallbacks):
+ENABLE_LOG_FILE = get_env_bool('IMMICH_ENABLE_LOG', True)
+SERVER = os.environ.get('IMMICH_SERVER', 'https://immich.example.com')
+API_KEY = os.environ.get('IMMICH_API_KEY', 'ENTER_YOUR_API_KEY_HERE')
+DRY_RUN = get_env_bool('IMMICH_DRY_RUN', True)
+DEFINITELY = get_env_bool('IMMICH_DEFINITELY', False)
 
 
 

--- a/immich_duplicates_en.py
+++ b/immich_duplicates_en.py
@@ -18,7 +18,8 @@ HEIC files (Apple originals), otherwise according to size, and finally EXIF meta
 - Ability to view files with their URLs in the logs
 
 Configuration can be provided via environment variables:
-  IMMICH_SERVER, IMMICH_API_KEY, IMMICH_ENABLE_LOG, IMMICH_DRY_RUN, IMMICH_DEFINITELY
+  IMMICH_SERVER, IMMICH_API_KEY, IMMICH_ENABLE_LOG, IMMICH_DRY_RUN, IMMICH_DEFINITELY,
+  IMMICH_ONLY_PAIRS, IMMICH_KEEP_METADATA, IMMICH_TRANSFER_METADATA
 
 Improvements welcome! Feel free to share with attribution.
 """
@@ -52,6 +53,9 @@ SERVER = os.environ.get('IMMICH_SERVER', 'https://immich.example.com')
 API_KEY = os.environ.get('IMMICH_API_KEY', 'ENTER_YOUR_API_KEY_HERE')
 DRY_RUN = get_env_bool('IMMICH_DRY_RUN', True)
 DEFINITELY = get_env_bool('IMMICH_DEFINITELY', False)
+ONLY_PAIRS = get_env_bool('IMMICH_ONLY_PAIRS', False)
+KEEP_METADATA = get_env_bool('IMMICH_KEEP_METADATA', True)
+TRANSFER_METADATA = get_env_bool('IMMICH_TRANSFER_METADATA', True)
 
 
 
@@ -149,36 +153,177 @@ def select_best_asset(assets):
     return remaining[0], reason
 
 
+def _has_exif_value(asset, key):
+    """Check if asset has a non-empty EXIF value."""
+    exif = asset.get('exifInfo') or {}
+    val = exif.get(key)
+    if val is None:
+        return False
+    if isinstance(val, str):
+        return bool(val.strip())
+    return True
+
+
+def _get_kept_tags_ids(kept):
+    """Return set of tag IDs the kept asset has."""
+    tags = kept.get('tags') or []
+    return {t['id'] for t in tags if t.get('id')}
+
+
+def remove_kept_metadata(kept, headers_get, headers_json):
+    """Remove albums and tags from kept asset when KEEP_METADATA=false."""
+    kept_id = kept['id']
+    try:
+        albums_resp = requests.get(
+            f"{SERVER}/api/albums", params={"assetId": kept_id}, headers=headers_get
+        )
+        albums_resp.raise_for_status()
+        albums = albums_resp.json()
+        for album in albums:
+            try:
+                del_resp = requests.delete(
+                    f"{SERVER}/api/albums/{album['id']}/assets",
+                    headers=headers_json,
+                    data=json.dumps({"ids": [kept_id]}),
+                )
+                if del_resp.status_code != 200:
+                    print(f"[WARN] Could not remove kept from album {album.get('albumName', album['id'])}: {del_resp.status_code}")
+            except requests.RequestException as e:
+                print(f"[WARN] Error removing kept from album: {e}")
+        for tag in (kept.get('tags') or []):
+            tag_id = tag.get('id')
+            if not tag_id:
+                continue
+            try:
+                del_resp = requests.delete(
+                    f"{SERVER}/api/tags/{tag_id}/assets",
+                    headers=headers_json,
+                    data=json.dumps({"ids": [kept_id]}),
+                )
+                if del_resp.status_code != 200:
+                    print(f"[WARN] Could not remove tag {tag.get('name', tag_id)} from kept: {del_resp.status_code}")
+            except requests.RequestException as e:
+                print(f"[WARN] Error removing tag from kept: {e}")
+    except requests.RequestException as e:
+        print(f"[WARN] Error fetching kept albums: {e}")
+
+
+def transfer_metadata_to_kept(kept, to_delete_assets, headers_get, headers_json):
+    """Transfer metadata from to_delete assets to kept (augment only, never overwrite)."""
+    kept_id = kept['id']
+    original_kept_tags = _get_kept_tags_ids(kept)
+    tags_to_add = set()
+    exif_to_set = {}  # fields to transfer: only where kept has none and to_delete has value
+
+    for to_del in to_delete_assets:
+        # Albums: add kept to each album to_delete is in
+        try:
+            albums_resp = requests.get(
+                f"{SERVER}/api/albums", params={"assetId": to_del['id']}, headers=headers_get
+            )
+            albums_resp.raise_for_status()
+            for album in albums_resp.json():
+                try:
+                    add_resp = requests.put(
+                        f"{SERVER}/api/albums/{album['id']}/assets",
+                        headers=headers_json,
+                        data=json.dumps({"ids": [kept_id]}),
+                    )
+                    if add_resp.status_code not in (200, 201):
+                        err_info = add_resp.json() if add_resp.text else {}
+                        if err_info and isinstance(err_info, list) and len(err_info) > 0 and err_info[0].get('error') == 'duplicate':
+                            pass  # already in album
+                        else:
+                            print(f"[WARN] Could not add kept to album: {add_resp.status_code}")
+                except requests.RequestException as e:
+                    print(f"[WARN] Error adding kept to album: {e}")
+        except requests.RequestException as e:
+            print(f"[WARN] Error fetching albums for to_delete {to_del['id']}: {e}")
+
+        # Tags: add only tags kept doesn't have
+        for tag in (to_del.get('tags') or []):
+            tag_id = tag.get('id')
+            if tag_id and tag_id not in original_kept_tags and tag_id not in tags_to_add:
+                tags_to_add.add(tag_id)
+        # EXIF: only fill gaps (to_delete has, kept doesn't)
+        exif = to_del.get('exifInfo') or {}
+        for key in ('latitude', 'longitude', 'description', 'dateTimeOriginal', 'rating'):
+            if key in exif_to_set:
+                continue  # already set from earlier to_delete
+            if _has_exif_value(to_del, key) and not _has_exif_value(kept, key):
+                raw = exif.get(key)
+                if raw is not None:
+                    exif_to_set[key] = raw
+
+    # Apply tags in one call (only new ones)
+    new_tag_ids = list(tags_to_add)
+    if new_tag_ids:
+        try:
+            tag_resp = requests.put(
+                f"{SERVER}/api/tags/assets",
+                headers=headers_json,
+                data=json.dumps({"assetIds": [kept_id], "tagIds": new_tag_ids}),
+            )
+            if tag_resp.status_code not in (200, 201):
+                print(f"[WARN] Could not add tags to kept: {tag_resp.status_code}")
+        except requests.RequestException as e:
+            print(f"[WARN] Error adding tags to kept: {e}")
+
+    # Apply EXIF in one call (only fields we're filling)
+    if exif_to_set:
+        payload = {"ids": [kept_id], **{k: v for k, v in exif_to_set.items()}}
+        try:
+            update_resp = requests.put(f"{SERVER}/api/assets", headers=headers_json, data=json.dumps(payload))
+            if update_resp.status_code not in (200, 204):
+                print(f"[WARN] Could not update EXIF on kept: {update_resp.status_code}")
+        except requests.RequestException as e:
+            print(f"[WARN] Error updating EXIF on kept: {e}")
+
+
 ids_to_delete = []
+processed_groups = []  # (kept, to_delete_assets) for metadata ops
 i = 0
 for group in duplicates:
     i = i + 1
     assets = group.get('assets')
+    if ONLY_PAIRS and len(assets) != 2:
+        print(f"[SKIPPED] Duplicates n°{i} ({len(assets)} files) - only pairs mode, manual selection recommended")
+        continue
     kept, reason = select_best_asset(assets)
+    to_delete_assets = [a for a in assets if a['id'] != kept['id']]
     date, is_heic, size, exif_count = get_asset_info(kept)
     date_str = date.strftime('%d/%m/%y - %H:%M:%S') if date != datetime.max else "??/??/??"
     print(f"\n[INFO] Duplicates n°{i} ({len(assets)} files), conservation reason : '{reason}'")
     print(f"[KEPT]\t\tDate : {date_str}\tSize : {round(size/1024/1024,2)}MB\t\tNumber of EXIF : {exif_count}\t{kept['originalFileName']} --> {SERVER}/api/assets/{kept['id']}/thumbnail?size=preview")
-    for asset in assets:
-        if asset['id'] != kept['id']:
-            date, is_heic, size, exif_count = get_asset_info(asset)
-            date_str = date.strftime('%d/%m/%y - %H:%M:%S') if date != datetime.max else "??/??/??"
-            print(f"[DELETED]\tDate : {date_str}\tSize : {round(size/1024/1024,2)}MB\t\tNumber of EXIF : {exif_count}\t{asset['originalFileName']} --> {SERVER}/api/assets/{asset['id']}/thumbnail?size=preview")
-            ids_to_delete.append(asset['id'])
+    for asset in to_delete_assets:
+        date, is_heic, size, exif_count = get_asset_info(asset)
+        date_str = date.strftime('%d/%m/%y - %H:%M:%S') if date != datetime.max else "??/??/??"
+        print(f"[DELETED]\tDate : {date_str}\tSize : {round(size/1024/1024,2)}MB\t\tNumber of EXIF : {exif_count}\t{asset['originalFileName']} --> {SERVER}/api/assets/{asset['id']}/thumbnail?size=preview")
+        ids_to_delete.append(asset['id'])
+    processed_groups.append((kept, to_delete_assets))
 
 
-# Step 3: Remove duplicates via the API
+# Step 3: Metadata operations (only when not dry run) then remove duplicates
+HEADERS_JSON = {
+    'Content-Type': 'application/json',
+    'x-api-key': API_KEY
+}
+HEADERS_GET = {'Accept': 'application/json', 'x-api-key': API_KEY}
+
 if DRY_RUN:
     print("\n[INFO] Simulation mode enabled. No actual deletion performed.")
     exit(0)
 
-HEADERS = {
-  'Content-Type': 'application/json',
-  'x-api-key': API_KEY
-}
+# Metadata: remove from kept (KEEP_METADATA=false) then transfer from to_delete (TRANSFER_METADATA=true)
+for kept, to_delete_assets in processed_groups:
+    if not KEEP_METADATA:
+        remove_kept_metadata(kept, HEADERS_GET, HEADERS_JSON)
+    if TRANSFER_METADATA and to_delete_assets:
+        transfer_metadata_to_kept(kept, to_delete_assets, HEADERS_GET, HEADERS_JSON)
+
 PAYLOAD = json.dumps({"force": DEFINITELY, "ids": ids_to_delete})
 try:
-    delete_response = requests.delete(f"{SERVER}/api/assets", headers=HEADERS, data=PAYLOAD)
+    delete_response = requests.delete(f"{SERVER}/api/assets", headers=HEADERS_JSON, data=PAYLOAD)
     delete_response.raise_for_status()
     print(f"\n[SUCCESS] Deletion successful.")
 except requests.RequestException:

--- a/immich_duplicates_fr.py
+++ b/immich_duplicates_fr.py
@@ -17,22 +17,41 @@ priorité aux fichiers HEIC (originaux d'apple), sinon selon la taille et enfin 
 - Journalisation détaillée dans un fichier .log si activée
 - Possibilité de visualiser les fichiers avec leur URL dans les logs
 
+Configuration via variables d'environnement :
+  IMMICH_SERVER, IMMICH_API_KEY, IMMICH_ENABLE_LOG, IMMICH_DRY_RUN, IMMICH_DEFINITELY
+
 Améliorations bienvenues ! Partage libre avec attribution.
 """
 
 
+import os
 import requests
 import json
 from datetime import datetime
 import sys
 
-# Configuration pour l'utilisateur :
-ENABLE_LOG_FILE = True # True = crée un fichier immich_duplicates.log, False = pas de fichier log
-SERVER = "https://immich.example.com"  # Remplacez par l'URL de votre serveur Immich ou à défaut, l'adresse IP
-API_KEY = "ENTER_YOUR_API_KEY_HERE" # Remplacez par votre clé API Immich
-DRY_RUN = True  # True = ne fait que simuler pour voir les fichiers choisis en sortie, ne supprime pas réellement
-# Mettre à False pour supprimer réellement les doublons
-DEFINITELY = False  # True = suppression définitive, False = dans la corbeille
+# Load .env file if python-dotenv is installed (optional)
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+def get_env_bool(name: str, default: bool) -> bool:
+    """Parse boolean from environment variable."""
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.lower() in ('true', '1', 'yes', 'on')
+
+
+# Configuration (variables d'environnement, avec valeurs par défaut) :
+ENABLE_LOG_FILE = get_env_bool('IMMICH_ENABLE_LOG', True)
+SERVER = os.environ.get('IMMICH_SERVER', 'https://immich.example.com')
+API_KEY = os.environ.get('IMMICH_API_KEY', 'ENTER_YOUR_API_KEY_HERE')
+DRY_RUN = get_env_bool('IMMICH_DRY_RUN', True)
+DEFINITELY = get_env_bool('IMMICH_DEFINITELY', False)
 
 
 

--- a/immich_duplicates_fr.py
+++ b/immich_duplicates_fr.py
@@ -18,7 +18,8 @@ priorité aux fichiers HEIC (originaux d'apple), sinon selon la taille et enfin 
 - Possibilité de visualiser les fichiers avec leur URL dans les logs
 
 Configuration via variables d'environnement :
-  IMMICH_SERVER, IMMICH_API_KEY, IMMICH_ENABLE_LOG, IMMICH_DRY_RUN, IMMICH_DEFINITELY
+  IMMICH_SERVER, IMMICH_API_KEY, IMMICH_ENABLE_LOG, IMMICH_DRY_RUN, IMMICH_DEFINITELY,
+  IMMICH_ONLY_PAIRS, IMMICH_KEEP_METADATA, IMMICH_TRANSFER_METADATA
 
 Améliorations bienvenues ! Partage libre avec attribution.
 """
@@ -52,6 +53,9 @@ SERVER = os.environ.get('IMMICH_SERVER', 'https://immich.example.com')
 API_KEY = os.environ.get('IMMICH_API_KEY', 'ENTER_YOUR_API_KEY_HERE')
 DRY_RUN = get_env_bool('IMMICH_DRY_RUN', True)
 DEFINITELY = get_env_bool('IMMICH_DEFINITELY', False)
+ONLY_PAIRS = get_env_bool('IMMICH_ONLY_PAIRS', False)
+KEEP_METADATA = get_env_bool('IMMICH_KEEP_METADATA', True)
+TRANSFER_METADATA = get_env_bool('IMMICH_TRANSFER_METADATA', True)
 
 
 
@@ -149,36 +153,171 @@ def select_best_asset(assets):
     return remaining[0], reason
 
 
+def _has_exif_value(asset, key):
+    """Vérifie si l'asset a une valeur EXIF non vide."""
+    exif = asset.get('exifInfo') or {}
+    val = exif.get(key)
+    if val is None:
+        return False
+    if isinstance(val, str):
+        return bool(val.strip())
+    return True
+
+
+def _get_kept_tags_ids(kept):
+    """Retourne l'ensemble des IDs de tags de l'asset gardé."""
+    tags = kept.get('tags') or []
+    return {t['id'] for t in tags if t.get('id')}
+
+
+def remove_kept_metadata(kept, headers_get, headers_json):
+    """Supprime albums et tags de l'asset gardé quand KEEP_METADATA=false."""
+    kept_id = kept['id']
+    try:
+        albums_resp = requests.get(
+            f"{SERVER}/api/albums", params={"assetId": kept_id}, headers=headers_get
+        )
+        albums_resp.raise_for_status()
+        albums = albums_resp.json()
+        for album in albums:
+            try:
+                del_resp = requests.delete(
+                    f"{SERVER}/api/albums/{album['id']}/assets",
+                    headers=headers_json,
+                    data=json.dumps({"ids": [kept_id]}),
+                )
+                if del_resp.status_code != 200:
+                    print(f"[WARN] Impossible de retirer le gardé de l'album {album.get('albumName', album['id'])} : {del_resp.status_code}")
+            except requests.RequestException as e:
+                print(f"[WARN] Erreur lors du retrait de l'album : {e}")
+        for tag in (kept.get('tags') or []):
+            tag_id = tag.get('id')
+            if not tag_id:
+                continue
+            try:
+                del_resp = requests.delete(
+                    f"{SERVER}/api/tags/{tag_id}/assets",
+                    headers=headers_json,
+                    data=json.dumps({"ids": [kept_id]}),
+                )
+                if del_resp.status_code != 200:
+                    print(f"[WARN] Impossible de retirer le tag {tag.get('name', tag_id)} du gardé : {del_resp.status_code}")
+            except requests.RequestException as e:
+                print(f"[WARN] Erreur lors du retrait du tag : {e}")
+    except requests.RequestException as e:
+        print(f"[WARN] Erreur lors de la récupération des albums du gardé : {e}")
+
+
+def transfer_metadata_to_kept(kept, to_delete_assets, headers_get, headers_json):
+    """Transfère les métadonnées des assets à supprimer vers le gardé (augmentation uniquement)."""
+    kept_id = kept['id']
+    original_kept_tags = _get_kept_tags_ids(kept)
+    tags_to_add = set()
+    exif_to_set = {}
+
+    for to_del in to_delete_assets:
+        try:
+            albums_resp = requests.get(
+                f"{SERVER}/api/albums", params={"assetId": to_del['id']}, headers=headers_get
+            )
+            albums_resp.raise_for_status()
+            for album in albums_resp.json():
+                try:
+                    add_resp = requests.put(
+                        f"{SERVER}/api/albums/{album['id']}/assets",
+                        headers=headers_json,
+                        data=json.dumps({"ids": [kept_id]}),
+                    )
+                    if add_resp.status_code not in (200, 201):
+                        err_info = add_resp.json() if add_resp.text else {}
+                        if err_info and isinstance(err_info, list) and len(err_info) > 0 and err_info[0].get('error') == 'duplicate':
+                            pass
+                        else:
+                            print(f"[WARN] Impossible d'ajouter le gardé à l'album : {add_resp.status_code}")
+                except requests.RequestException as e:
+                    print(f"[WARN] Erreur lors de l'ajout à l'album : {e}")
+        except requests.RequestException as e:
+            print(f"[WARN] Erreur lors de la récupération des albums du to_delete {to_del['id']} : {e}")
+
+        for tag in (to_del.get('tags') or []):
+            tag_id = tag.get('id')
+            if tag_id and tag_id not in original_kept_tags and tag_id not in tags_to_add:
+                tags_to_add.add(tag_id)
+        exif = to_del.get('exifInfo') or {}
+        for key in ('latitude', 'longitude', 'description', 'dateTimeOriginal', 'rating'):
+            if key in exif_to_set:
+                continue
+            if _has_exif_value(to_del, key) and not _has_exif_value(kept, key):
+                raw = exif.get(key)
+                if raw is not None:
+                    exif_to_set[key] = raw
+
+    new_tag_ids = list(tags_to_add)
+    if new_tag_ids:
+        try:
+            tag_resp = requests.put(
+                f"{SERVER}/api/tags/assets",
+                headers=headers_json,
+                data=json.dumps({"assetIds": [kept_id], "tagIds": new_tag_ids}),
+            )
+            if tag_resp.status_code not in (200, 201):
+                print(f"[WARN] Impossible d'ajouter les tags au gardé : {tag_resp.status_code}")
+        except requests.RequestException as e:
+            print(f"[WARN] Erreur lors de l'ajout des tags : {e}")
+
+    if exif_to_set:
+        payload = {"ids": [kept_id], **{k: v for k, v in exif_to_set.items()}}
+        try:
+            update_resp = requests.put(f"{SERVER}/api/assets", headers=headers_json, data=json.dumps(payload))
+            if update_resp.status_code not in (200, 204):
+                print(f"[WARN] Impossible de mettre à jour l'EXIF du gardé : {update_resp.status_code}")
+        except requests.RequestException as e:
+            print(f"[WARN] Erreur lors de la mise à jour de l'EXIF : {e}")
+
+
 ids_to_delete = []
+processed_groups = []
 i = 0
 for group in duplicates:
     i = i + 1
     assets = group.get('assets')
+    if ONLY_PAIRS and len(assets) != 2:
+        print(f"[IGNORÉ] Doublons n°{i} ({len(assets)} fichiers) - mode paires uniquement, sélection manuelle recommandée")
+        continue
     kept, reason = select_best_asset(assets)
+    to_delete_assets = [a for a in assets if a['id'] != kept['id']]
     date, is_heic, size, exif_count = get_asset_info(kept)
     date_str = date.strftime('%d/%m/%y - %H:%M:%S') if date != datetime.max else "??/??/??"
     print(f"\n[INFO] Doublons n°{i} ({len(assets)} fichiers), raison de conservation : '{reason}'")
     print(f"[GARDÉ]\t\tDate : {date_str}\tTaille : {round(size/1024/1024,2)}MB\t\tNombre d'exif : {exif_count}\t{kept['originalFileName']} --> {SERVER}/api/assets/{kept['id']}/thumbnail?size=preview")
-    for asset in assets:
-        if asset['id'] != kept['id']:
-            date, is_heic, size, exif_count = get_asset_info(asset)
-            date_str = date.strftime('%d/%m/%y - %H:%M:%S') if date != datetime.max else "??/??/??"
-            print(f"[SUPPRIMÉ]\tDate : {date_str}\tTaille : {round(size/1024/1024,2)}MB\t\tNombre d'exif : {exif_count}\t{asset['originalFileName']} --> {SERVER}/api/assets/{asset['id']}/thumbnail?size=preview")
-            ids_to_delete.append(asset['id'])
+    for asset in to_delete_assets:
+        date, is_heic, size, exif_count = get_asset_info(asset)
+        date_str = date.strftime('%d/%m/%y - %H:%M:%S') if date != datetime.max else "??/??/??"
+        print(f"[SUPPRIMÉ]\tDate : {date_str}\tTaille : {round(size/1024/1024,2)}MB\t\tNombre d'exif : {exif_count}\t{asset['originalFileName']} --> {SERVER}/api/assets/{asset['id']}/thumbnail?size=preview")
+        ids_to_delete.append(asset['id'])
+    processed_groups.append((kept, to_delete_assets))
 
 
-# Étape 3 : Supprimer les doublons via l'API
+# Étape 3 : Métadonnées puis suppression des doublons
+HEADERS_JSON = {
+    'Content-Type': 'application/json',
+    'x-api-key': API_KEY
+}
+HEADERS_GET = {'Accept': 'application/json', 'x-api-key': API_KEY}
+
 if DRY_RUN:
     print("\n[INFO] Mode simulation activé. Aucune suppression réelle effectuée.")
     exit(0)
 
-HEADERS = {
-  'Content-Type': 'application/json',
-  'x-api-key': API_KEY
-}
+for kept, to_delete_assets in processed_groups:
+    if not KEEP_METADATA:
+        remove_kept_metadata(kept, HEADERS_GET, HEADERS_JSON)
+    if TRANSFER_METADATA and to_delete_assets:
+        transfer_metadata_to_kept(kept, to_delete_assets, HEADERS_GET, HEADERS_JSON)
+
 PAYLOAD = json.dumps({"force": DEFINITELY, "ids": ids_to_delete})
 try:
-    delete_response = requests.delete(f"{SERVER}/api/assets", headers=HEADERS, data=PAYLOAD)
+    delete_response = requests.delete(f"{SERVER}/api/assets", headers=HEADERS_JSON, data=PAYLOAD)
     delete_response.raise_for_status()
     print(f"\n[SUCCESS] Suppression réussie.")
 except requests.RequestException:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.28.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
# Pull Request: Enhancements for Large-Scale Duplicate Cleanup

## Summary

This PR introduces several enhancements to the Immich Duplicate Cleaner script to make it more robust, configurable, and suitable for **large-scale library operations**. These improvements were developed and tested during a Synology-to-Immich migration involving **over 17,000 duplicate groups** (~17,000 assets removed).

---

## Motivation

When migrating a large photo library (e.g., from Synology Photos to Immich), duplicate detection often yields thousands of groups. The original script processed each group individually and lacked:

- **Batch deletion** – sending all asset IDs in a single request could exceed API limits or cause timeouts
- **Progress visibility** – no feedback during long-running metadata transfers
- **Configurable timeouts** – slow or remote servers needed longer request timeouts
- **Metadata preservation** – albums, tags, and location data from deleted assets were lost

This PR addresses these limitations and adds optional features for safer, more controlled duplicate cleanup.

---

## Changes Overview

### 1. Environment Variable & `.env` File Support

- **New file:** `.env.example` – template for all configuration options
- **Optional dependency:** `python-dotenv` for loading `.env` automatically
- All settings (API key, server URL, feature flags, etc.) can be configured via environment variables instead of editing the script

### 2. Only-Pairs Mode (`IMMICH_ONLY_PAIRS`)

- When `true`, the script processes only duplicate groups with **exactly 2 files** (e.g. JPG + HEIC)
- Groups with 3 or more files are skipped (recommended for manual selection)
- Reduces risk of accidentally deleting the wrong file in ambiguous groups

### 3. Metadata Transfer (`IMMICH_TRANSFER_METADATA`)

- **Albums:** Kept asset is added to all albums the deleted assets belonged to
- **Tags:** Tags from deleted assets are merged onto the kept asset (no duplicates)
- **EXIF/Location:** Latitude, longitude, description, date, rating – transferred only where the kept asset has no value (augment-only, never overwrite)

### 4. Metadata Control (`IMMICH_KEEP_METADATA`)

- `true` (default): Kept asset retains its existing metadata; deleted metadata is merged in
- `false`: Kept asset’s albums and tags are removed first, then metadata from deleted assets is transferred (clean slate)

### 5. Interactive Confirmation Mode (`IMMICH_CONFIRM`)

- When `true`, prompts `[Y/n]` before processing each duplicate group
- With `DRY_RUN=true`: only logs the choice
- With `DRY_RUN=false`: processes immediately after confirmation
- Useful for fine-grained control over which groups to process

### 6. Request Timeout (`IMMICH_REQUEST_TIMEOUT`)

- Configurable timeout in seconds for all API requests (default: 5)
- Helps avoid hangs on slow or remote Immich servers
- Can be increased for large libraries or poor network conditions

### 7. Batch Deletion (`IMMICH_DELETE_BATCH_SIZE`)

- Assets are deleted in configurable batches (default: 500) instead of one large request
- Reduces payload size, avoids API limits, and improves reliability
- Failed batches are reported; successful batches still complete

### 8. Progress Logging

- **Group processing:** Progress message every 500 groups when not using confirm mode
- **Metadata transfer:** Progress message every 100 groups
- **Deletion:** Per-batch status (e.g. `Batch 1/35: 500 assets deleted.`)

### 9. Documentation Updates (README)

- Installation instructions (venv, dependencies)
- Configuration reference for all environment variables
- API key permissions table (which Immich permissions are required)
- Usage examples and tips (dry run, confirm mode)
- Bilingual README (English and French) updated for all new options

---

## API Key Permissions

| Permission           | Purpose                                              |
|----------------------|------------------------------------------------------|
| `duplicate.read`     | Retrieve duplicate groups                            |
| `asset.delete`       | Delete duplicate assets                              |
| `asset.update`       | Transfer location/EXIF (when `IMMICH_TRANSFER_METADATA=true`) |
| `album.read`         | Read album memberships                               |
| `album.asset.create`| Add kept asset to albums                             |
| `album.asset.delete`| Remove kept from albums (when `IMMICH_KEEP_METADATA=false`) |
| `tag.asset`          | Add/remove tags for metadata transfer                |

A full-access API key covers all of these.

---

## Real-World Test: Synology Migration (17,032 Assets)

The script was used during a Synology Photos → Immich migration. Below is the log output from processing **17,032 duplicate groups**:

<details>
<summary>Click to expand full log</summary>

```
[INFO] Transferring metadata for 17032 groups...
[INFO] Metadata progress: 100/17032 groups...
[INFO] Metadata progress: 200/17032 groups...
[INFO] Metadata progress: 300/17032 groups...
[INFO] Metadata progress: 400/17032 groups...
[INFO] Metadata progress: 500/17032 groups...
[INFO] Metadata progress: 600/17032 groups...
[INFO] Metadata progress: 700/17032 groups...
[INFO] Metadata progress: 800/17032 groups...
[INFO] Metadata progress: 900/17032 groups...
[INFO] Metadata progress: 1000/17032 groups...
[INFO] Metadata progress: 1100/17032 groups...
[INFO] Metadata progress: 1200/17032 groups...
[INFO] Metadata progress: 1300/17032 groups...
[INFO] Metadata progress: 1400/17032 groups...
[INFO] Metadata progress: 1500/17032 groups...
[INFO] Metadata progress: 1600/17032 groups...
[INFO] Metadata progress: 1700/17032 groups...
[INFO] Metadata progress: 1800/17032 groups...
[INFO] Metadata progress: 1900/17032 groups...
[INFO] Metadata progress: 2000/17032 groups...
[INFO] Metadata progress: 2100/17032 groups...
[INFO] Metadata progress: 2200/17032 groups...
[INFO] Metadata progress: 2300/17032 groups...
[INFO] Metadata progress: 2400/17032 groups...
[INFO] Metadata progress: 2500/17032 groups...
[INFO] Metadata progress: 2600/17032 groups...
[INFO] Metadata progress: 2700/17032 groups...
[INFO] Metadata progress: 2800/17032 groups...
[INFO] Metadata progress: 2900/17032 groups...
[INFO] Metadata progress: 3000/17032 groups...
[INFO] Metadata progress: 3100/17032 groups...
[INFO] Metadata progress: 3200/17032 groups...
[INFO] Metadata progress: 3300/17032 groups...
[INFO] Metadata progress: 3400/17032 groups...
[INFO] Metadata progress: 3500/17032 groups...
[INFO] Metadata progress: 3600/17032 groups...
[INFO] Metadata progress: 3700/17032 groups...
[INFO] Metadata progress: 3800/17032 groups...
[INFO] Metadata progress: 3900/17032 groups...
[INFO] Metadata progress: 4000/17032 groups...
[INFO] Metadata progress: 4100/17032 groups...
[INFO] Metadata progress: 4200/17032 groups...
[INFO] Metadata progress: 4300/17032 groups...
[INFO] Metadata progress: 4400/17032 groups...
[INFO] Metadata progress: 4500/17032 groups...
[INFO] Metadata progress: 4600/17032 groups...
[INFO] Metadata progress: 4700/17032 groups...
[INFO] Metadata progress: 4800/17032 groups...
[INFO] Metadata progress: 4900/17032 groups...
[INFO] Metadata progress: 5000/17032 groups...
[INFO] Metadata progress: 5100/17032 groups...
[INFO] Metadata progress: 5200/17032 groups...
[INFO] Metadata progress: 5300/17032 groups...
[INFO] Metadata progress: 5400/17032 groups...
[INFO] Metadata progress: 5500/17032 groups...
[INFO] Metadata progress: 5600/17032 groups...
[INFO] Metadata progress: 5700/17032 groups...
[INFO] Metadata progress: 5800/17032 groups...
[INFO] Metadata progress: 5900/17032 groups...
[INFO] Metadata progress: 6000/17032 groups...
[INFO] Metadata progress: 6100/17032 groups...
[INFO] Metadata progress: 6200/17032 groups...
[INFO] Metadata progress: 6300/17032 groups...
[INFO] Metadata progress: 6400/17032 groups...
[INFO] Metadata progress: 6500/17032 groups...
[INFO] Metadata progress: 6600/17032 groups...
[INFO] Metadata progress: 6700/17032 groups...
[INFO] Metadata progress: 6800/17032 groups...
[INFO] Metadata progress: 6900/17032 groups...
[INFO] Metadata progress: 7000/17032 groups...
[INFO] Metadata progress: 7100/17032 groups...
[INFO] Metadata progress: 7200/17032 groups...
[INFO] Metadata progress: 7300/17032 groups...
[INFO] Metadata progress: 7400/17032 groups...
[INFO] Metadata progress: 7500/17032 groups...
[INFO] Metadata progress: 7600/17032 groups...
[INFO] Metadata progress: 7700/17032 groups...
[INFO] Metadata progress: 7800/17032 groups...
[INFO] Metadata progress: 7900/17032 groups...
[INFO] Metadata progress: 8000/17032 groups...
[INFO] Metadata progress: 8100/17032 groups...
[INFO] Metadata progress: 8200/17032 groups...
[INFO] Metadata progress: 8300/17032 groups...
[INFO] Metadata progress: 8400/17032 groups...
[INFO] Metadata progress: 8500/17032 groups...
[INFO] Metadata progress: 8600/17032 groups...
[INFO] Metadata progress: 8700/17032 groups...
[INFO] Metadata progress: 8800/17032 groups...
[INFO] Metadata progress: 8900/17032 groups...
[INFO] Metadata progress: 9000/17032 groups...
[INFO] Metadata progress: 9100/17032 groups...
[INFO] Metadata progress: 9200/17032 groups...
[INFO] Metadata progress: 9300/17032 groups...
[INFO] Metadata progress: 9400/17032 groups...
[INFO] Metadata progress: 9500/17032 groups...
[INFO] Metadata progress: 9600/17032 groups...
[INFO] Metadata progress: 9700/17032 groups...
[INFO] Metadata progress: 9800/17032 groups...
[INFO] Metadata progress: 9900/17032 groups...
[INFO] Metadata progress: 10000/17032 groups...
[INFO] Metadata progress: 10100/17032 groups...
[INFO] Metadata progress: 10200/17032 groups...
[INFO] Metadata progress: 10300/17032 groups...
[INFO] Metadata progress: 10400/17032 groups...
[INFO] Metadata progress: 10500/17032 groups...
[INFO] Metadata progress: 10600/17032 groups...
[INFO] Metadata progress: 10700/17032 groups...
[INFO] Metadata progress: 10800/17032 groups...
[INFO] Metadata progress: 10900/17032 groups...
[INFO] Metadata progress: 11000/17032 groups...
[INFO] Metadata progress: 11100/17032 groups...
[INFO] Metadata progress: 11200/17032 groups...
[INFO] Metadata progress: 11300/17032 groups...
[INFO] Metadata progress: 11400/17032 groups...
[INFO] Metadata progress: 11500/17032 groups...
[INFO] Metadata progress: 11600/17032 groups...
[INFO] Metadata progress: 11700/17032 groups...
[INFO] Metadata progress: 11800/17032 groups...
[INFO] Metadata progress: 11900/17032 groups...
[INFO] Metadata progress: 12000/17032 groups...
[INFO] Metadata progress: 12100/17032 groups...
[INFO] Metadata progress: 12200/17032 groups...
[INFO] Metadata progress: 12300/17032 groups...
[INFO] Metadata progress: 12400/17032 groups...
[INFO] Metadata progress: 12500/17032 groups...
[INFO] Metadata progress: 12600/17032 groups...
[INFO] Metadata progress: 12700/17032 groups...
[INFO] Metadata progress: 12800/17032 groups...
[INFO] Metadata progress: 12900/17032 groups...
[INFO] Metadata progress: 13000/17032 groups...
[INFO] Metadata progress: 13100/17032 groups...
[INFO] Metadata progress: 13200/17032 groups...
[INFO] Metadata progress: 13300/17032 groups...
[INFO] Metadata progress: 13400/17032 groups...
[INFO] Metadata progress: 13500/17032 groups...
[INFO] Metadata progress: 13600/17032 groups...
[INFO] Metadata progress: 13700/17032 groups...
[INFO] Metadata progress: 13800/17032 groups...
[INFO] Metadata progress: 13900/17032 groups...
[INFO] Metadata progress: 14000/17032 groups...
[INFO] Metadata progress: 14100/17032 groups...
[INFO] Metadata progress: 14200/17032 groups...
[INFO] Metadata progress: 14300/17032 groups...
[INFO] Metadata progress: 14400/17032 groups...
[INFO] Metadata progress: 14500/17032 groups...
[INFO] Metadata progress: 14600/17032 groups...
[INFO] Metadata progress: 14700/17032 groups...
[INFO] Metadata progress: 14800/17032 groups...
[INFO] Metadata progress: 14900/17032 groups...
[INFO] Metadata progress: 15000/17032 groups...
[INFO] Metadata progress: 15100/17032 groups...
[INFO] Metadata progress: 15200/17032 groups...
[INFO] Metadata progress: 15300/17032 groups...
[INFO] Metadata progress: 15400/17032 groups...
[INFO] Metadata progress: 15500/17032 groups...
[INFO] Metadata progress: 15600/17032 groups...
[INFO] Metadata progress: 15700/17032 groups...
[INFO] Metadata progress: 15800/17032 groups...
[INFO] Metadata progress: 15900/17032 groups...
[INFO] Metadata progress: 16000/17032 groups...
[INFO] Metadata progress: 16100/17032 groups...
[INFO] Metadata progress: 16200/17032 groups...
[INFO] Metadata progress: 16300/17032 groups...
[INFO] Metadata progress: 16400/17032 groups...
[INFO] Metadata progress: 16500/17032 groups...
[INFO] Metadata progress: 16600/17032 groups...
[INFO] Metadata progress: 16700/17032 groups...
[INFO] Metadata progress: 16800/17032 groups...
[INFO] Metadata progress: 16900/17032 groups...
[INFO] Metadata progress: 17000/17032 groups...
[INFO] Deleting 17032 assets in 35 batches (batch size: 500)...
[INFO] Batch 1/35: 500 assets deleted.
[INFO] Batch 2/35: 500 assets deleted.
[INFO] Batch 3/35: 500 assets deleted.
[INFO] Batch 4/35: 500 assets deleted.
[INFO] Batch 5/35: 500 assets deleted.
[INFO] Batch 6/35: 500 assets deleted.
[INFO] Batch 7/35: 500 assets deleted.
[INFO] Batch 8/35: 500 assets deleted.
[INFO] Batch 9/35: 500 assets deleted.
[INFO] Batch 10/35: 500 assets deleted.
[INFO] Batch 11/35: 500 assets deleted.
[INFO] Batch 12/35: 500 assets deleted.
[INFO] Batch 13/35: 500 assets deleted.
[INFO] Batch 14/35: 500 assets deleted.
[INFO] Batch 15/35: 500 assets deleted.
[INFO] Batch 16/35: 500 assets deleted.
[INFO] Batch 17/35: 500 assets deleted.
[INFO] Batch 18/35: 500 assets deleted.
[INFO] Batch 19/35: 500 assets deleted.
[INFO] Batch 20/35: 500 assets deleted.
[INFO] Batch 21/35: 500 assets deleted.
[INFO] Batch 22/35: 500 assets deleted.
[INFO] Batch 23/35: 500 assets deleted.
[INFO] Batch 24/35: 500 assets deleted.
[INFO] Batch 25/35: 500 assets deleted.
[INFO] Batch 26/35: 500 assets deleted.
[INFO] Batch 27/35: 500 assets deleted.
[INFO] Batch 28/35: 500 assets deleted.
[INFO] Batch 29/35: 500 assets deleted.
[INFO] Batch 30/35: 500 assets deleted.
[INFO] Batch 31/35: 500 assets deleted.
[INFO] Batch 32/35: 500 assets deleted.
[INFO] Batch 33/35: 500 assets deleted.
[INFO] Batch 34/35: 500 assets deleted.
[INFO] Batch 35/35: 32 assets deleted.

[SUCCESS] Deletion complete. 17032 assets removed.
```

</details>

**Result:** 17,032 assets successfully removed in 35 batches. Metadata (albums, tags, location) was transferred from deleted duplicates to the kept assets across all 17,032 groups.

---

## Backward Compatibility

- All new options have sensible defaults; existing workflows continue to work unchanged
- `IMMICH_ONLY_PAIRS=false` – process all groups (original behavior)
- `IMMICH_TRANSFER_METADATA=true` – metadata transfer enabled (recommended)
- `IMMICH_CONFIRM=false` – bulk processing without prompts (original behavior)
- `python-dotenv` is optional; configuration can still be done via environment variables only

---

## Files Changed

| File | Description |
|------|-------------|
| `immich_duplicates_en.py` | English script: metadata transfer, batch deletion, timeouts, progress logging |
| `immich_duplicates_fr.py` | French script: same changes, translated messages |
| `README.md` | Installation, configuration, API permissions, usage docs (EN + FR) |
| `.env.example` | New: configuration template |

---

## Checklist

- [x] Both English and French scripts updated
- [x] README documentation updated (bilingual)
- [x] `.env.example` provided
- [x] Backward compatible with existing usage
- [x] Tested with 17,000+ duplicate groups (Synology migration)

---

## Acknowledgments

Original script by **Sébastien Castermans**. These enhancements build on that foundation to support large-scale duplicate cleanup and metadata preservation.